### PR TITLE
Feature/oro 100 implement settings system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,8 @@ add_library(orogena_gui
     gui/gui_main_window.h
     gui/gui_global_viewport.cpp
     gui/gui_global_viewport.h
+    gui/gui_qt_settings.cpp
+    gui/gui_qt_settings.h
 )
 
 target_link_libraries(orogena_gui

--- a/src/core/core_settings_interface.h
+++ b/src/core/core_settings_interface.h
@@ -1,0 +1,83 @@
+/**************************************************************************************************/
+/**
+ * @file core_settings_interface.h
+ * @brief Abstract interface for application settings
+ *
+ * @details
+ * Defines a pure C++ interface for settings management, keeping Qt dependencies out of core logic.
+ * Implementations can use QSettings or other backends while maintaining framework independence.
+ *
+ * @author Diego Torres
+ * @date 2025
+ * @copyright Copyright (C) 2025 Diego Torres. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+/**************************************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+#include "utils/utils_types.h"
+
+namespace Orogena::Core
+{
+
+/**
+ * @brief Abstract interface for application settings
+ *
+ * @details
+ * Provides a framework-independent interface for reading and writing application settings.
+ * All methods use standard C++ types (std::string, std::optional) to avoid Qt dependencies.
+ *
+ * Settings are organized by keys (e.g., "window/geometry", "simulation/plateCount").
+ * Missing values return std::nullopt to distinguish between "not set" and "set to default".
+ *
+ * Thread Safety: Implementation-dependent. Qt-based implementations are thread-safe.
+ */
+class ISettings
+{
+public:
+    virtual ~ISettings() = default;
+
+    // String settings
+    virtual void SetString(const std::string& key, const std::string& value) = 0;
+    virtual std::optional<std::string> GetString(const std::string& key) const = 0;
+
+    // Integer settings
+    virtual void SetInt(const std::string& key, int32_t value) = 0;
+    virtual std::optional<int32_t> GetInt(const std::string& key) const = 0;
+
+    // 64-bit integer settings
+    virtual void SetInt64(const std::string& key, int64_t value) = 0;
+    virtual std::optional<int64_t> GetInt64(const std::string& key) const = 0;
+
+    // Floating-point settings
+    virtual void SetFloat(const std::string& key, float64_t value) = 0;
+    virtual std::optional<float64_t> GetFloat(const std::string& key) const = 0;
+
+    // Boolean settings
+    virtual void SetBool(const std::string& key, bool value) = 0;
+    virtual std::optional<bool> GetBool(const std::string& key) const = 0;
+
+    // String list settings (e.g., recent projects)
+    virtual void SetStringList(const std::string& key, const std::vector<std::string>& value) = 0;
+    virtual std::optional<std::vector<std::string>> GetStringList(const std::string& key) const = 0;
+
+    // Utility methods
+    virtual bool Contains(const std::string& key) const = 0;
+    virtual void Remove(const std::string& key) = 0;
+    virtual void Clear() = 0;
+    virtual void Sync() = 0; ///< Force write to persistent storage
+
+    // Group management (for hierarchical settings)
+    virtual void BeginGroup(const std::string& prefix) = 0;
+    virtual void EndGroup() = 0;
+};
+
+} // namespace Orogena::Core

--- a/src/gui/gui_qt_settings.cpp
+++ b/src/gui/gui_qt_settings.cpp
@@ -1,0 +1,219 @@
+/**************************************************************************************************/
+/**
+ * @file gui_qt_settings.cpp
+ * @brief Qt-based implementation of ISettings interface
+ *
+ * @author Diego Torres
+ * @date 2025
+ * @copyright Copyright (C) 2025 Diego Torres. All rights reserved.
+ */
+/**************************************************************************************************/
+
+#include "gui_qt_settings.h"
+#include <QStringList>
+
+namespace Orogena::GUI
+{
+
+//=============================================================================================
+// Constructors
+//=============================================================================================
+
+QtSettings::QtSettings()
+    : m_Settings{"Orogena", "Orogena"}
+{
+}
+
+QtSettings::QtSettings(const std::string& organization, const std::string& application)
+    : m_Settings{QString::fromStdString(organization), QString::fromStdString(application)}
+{
+}
+
+//=============================================================================================
+// String Settings
+//=============================================================================================
+
+void QtSettings::SetString(const std::string& key, const std::string& value)
+{
+    m_Settings.setValue(QString::fromStdString(key), QString::fromStdString(value));
+}
+
+std::optional<std::string> QtSettings::GetString(const std::string& key) const
+{
+    QVariant value = m_Settings.value(QString::fromStdString(key));
+    if (!value.isValid())
+    {
+        return std::nullopt;
+    }
+    return value.toString().toStdString();
+}
+
+//=============================================================================================
+// Integer Settings
+//=============================================================================================
+
+void QtSettings::SetInt(const std::string& key, int32_t value)
+{
+    m_Settings.setValue(QString::fromStdString(key), value);
+}
+
+std::optional<int32_t> QtSettings::GetInt(const std::string& key) const
+{
+    QVariant value = m_Settings.value(QString::fromStdString(key));
+    if (!value.isValid())
+    {
+        return std::nullopt;
+    }
+
+    bool ok = false;
+    int32_t result = value.toInt(&ok);
+    if (!ok)
+    {
+        return std::nullopt;
+    }
+    return result;
+}
+
+//=============================================================================================
+// 64-bit Integer Settings
+//=============================================================================================
+
+void QtSettings::SetInt64(const std::string& key, int64_t value)
+{
+    m_Settings.setValue(QString::fromStdString(key), static_cast<qlonglong>(value));
+}
+
+std::optional<int64_t> QtSettings::GetInt64(const std::string& key) const
+{
+    QVariant value = m_Settings.value(QString::fromStdString(key));
+    if (!value.isValid())
+    {
+        return std::nullopt;
+    }
+
+    bool ok = false;
+    int64_t result = value.toLongLong(&ok);
+    if (!ok)
+    {
+        return std::nullopt;
+    }
+    return result;
+}
+
+//=============================================================================================
+// Floating-point Settings
+//=============================================================================================
+
+void QtSettings::SetFloat(const std::string& key, float64_t value)
+{
+    m_Settings.setValue(QString::fromStdString(key), value);
+}
+
+std::optional<float64_t> QtSettings::GetFloat(const std::string& key) const
+{
+    QVariant value = m_Settings.value(QString::fromStdString(key));
+    if (!value.isValid())
+    {
+        return std::nullopt;
+    }
+
+    bool ok = false;
+    float64_t result = value.toDouble(&ok);
+    if (!ok)
+    {
+        return std::nullopt;
+    }
+    return result;
+}
+
+//=============================================================================================
+// Boolean Settings
+//=============================================================================================
+
+void QtSettings::SetBool(const std::string& key, bool value)
+{
+    m_Settings.setValue(QString::fromStdString(key), value);
+}
+
+std::optional<bool> QtSettings::GetBool(const std::string& key) const
+{
+    QVariant value = m_Settings.value(QString::fromStdString(key));
+    if (!value.isValid())
+    {
+        return std::nullopt;
+    }
+    return value.toBool();
+}
+
+//=============================================================================================
+// String List Settings
+//=============================================================================================
+
+void QtSettings::SetStringList(const std::string& key, const std::vector<std::string>& value)
+{
+    QStringList qList;
+    qList.reserve(static_cast<int>(value.size()));
+    for (const auto& str : value)
+    {
+        qList.append(QString::fromStdString(str));
+    }
+    m_Settings.setValue(QString::fromStdString(key), qList);
+}
+
+std::optional<std::vector<std::string>> QtSettings::GetStringList(const std::string& key) const
+{
+    QVariant value = m_Settings.value(QString::fromStdString(key));
+    if (!value.isValid())
+    {
+        return std::nullopt;
+    }
+
+    QStringList qList = value.toStringList();
+    std::vector<std::string> result;
+    result.reserve(static_cast<size_t>(qList.size()));
+    for (const auto& str : qList)
+    {
+        result.push_back(str.toStdString());
+    }
+    return result;
+}
+
+//=============================================================================================
+// Utility Methods
+//=============================================================================================
+
+bool QtSettings::Contains(const std::string& key) const
+{
+    return m_Settings.contains(QString::fromStdString(key));
+}
+
+void QtSettings::Remove(const std::string& key)
+{
+    m_Settings.remove(QString::fromStdString(key));
+}
+
+void QtSettings::Clear()
+{
+    m_Settings.clear();
+}
+
+void QtSettings::Sync()
+{
+    m_Settings.sync();
+}
+
+//=============================================================================================
+// Group Management
+//=============================================================================================
+
+void QtSettings::BeginGroup(const std::string& prefix)
+{
+    m_Settings.beginGroup(QString::fromStdString(prefix));
+}
+
+void QtSettings::EndGroup()
+{
+    m_Settings.endGroup();
+}
+
+} // namespace Orogena::GUI

--- a/src/gui/gui_qt_settings.h
+++ b/src/gui/gui_qt_settings.h
@@ -1,0 +1,97 @@
+/**************************************************************************************************/
+/**
+ * @file gui_qt_settings.h
+ * @brief Qt-based implementation of ISettings interface
+ *
+ * @details
+ * Provides a QSettings-backed implementation of the ISettings interface.
+ * Converts between Qt types (QString, QVariant) and standard C++ types at the boundary.
+ *
+ * Organization: "Orogena"
+ * Application: "Orogena"
+ *
+ * @author Diego Torres
+ * @date 2025
+ * @copyright Copyright (C) 2025 Diego Torres. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+/**************************************************************************************************/
+
+#pragma once
+
+#include <QSettings>
+#include "core/core_settings_interface.h"
+
+namespace Orogena::GUI
+{
+
+/**
+ * @brief Qt-based settings implementation using QSettings
+ *
+ * @details
+ * Thread-safe implementation backed by QSettings. All Qt types are converted to/from
+ * standard C++ types at the boundary to maintain framework independence in core logic.
+ *
+ * Settings are stored platform-specifically:
+ * - Linux: ~/.config/Orogena/Orogena.conf
+ * - Windows: HKEY_CURRENT_USER\Software\Orogena\Orogena
+ * - macOS: ~/Library/Preferences/com.Orogena.Orogena.plist
+ */
+class QtSettings : public Core::ISettings
+{
+public:
+    /**
+     * @brief Constructs settings with default organization and application name
+     */
+    QtSettings();
+
+    /**
+     * @brief Constructs settings with custom organization and application name
+     */
+    QtSettings(const std::string& organization, const std::string& application);
+
+    ~QtSettings() override = default;
+
+    // String settings
+    void SetString(const std::string& key, const std::string& value) override;
+    std::optional<std::string> GetString(const std::string& key) const override;
+
+    // Integer settings
+    void SetInt(const std::string& key, int32_t value) override;
+    std::optional<int32_t> GetInt(const std::string& key) const override;
+
+    // 64-bit integer settings
+    void SetInt64(const std::string& key, int64_t value) override;
+    std::optional<int64_t> GetInt64(const std::string& key) const override;
+
+    // Floating-point settings
+    void SetFloat(const std::string& key, float64_t value) override;
+    std::optional<float64_t> GetFloat(const std::string& key) const override;
+
+    // Boolean settings
+    void SetBool(const std::string& key, bool value) override;
+    std::optional<bool> GetBool(const std::string& key) const override;
+
+    // String list settings
+    void SetStringList(const std::string& key, const std::vector<std::string>& value) override;
+    std::optional<std::vector<std::string>> GetStringList(const std::string& key) const override;
+
+    // Utility methods
+    bool Contains(const std::string& key) const override;
+    void Remove(const std::string& key) override;
+    void Clear() override;
+    void Sync() override;
+
+    // Group management
+    void BeginGroup(const std::string& prefix) override;
+    void EndGroup() override;
+
+private:
+    QSettings m_Settings;
+};
+
+} // namespace Orogena::GUI

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include(GoogleTest)
 add_executable(test_unit
     unit/database/test_database_manager.cpp
     unit/utils/test_logger.cpp
+    unit/gui/test_qt_settings.cpp
 )
 
 target_link_libraries(test_unit
@@ -14,6 +15,8 @@ target_link_libraries(test_unit
         GTest::gtest_main
         orogena_database
         orogena_utils
+        orogena_gui
+        Qt6::Core
 )
 
 gtest_discover_tests(test_unit)

--- a/tests/unit/gui/test_qt_settings.cpp
+++ b/tests/unit/gui/test_qt_settings.cpp
@@ -1,0 +1,498 @@
+/**************************************************************************************************/
+/**
+ * @file test_qt_settings.cpp
+ * @brief Unit tests for QtSettings implementation
+ *
+ * @author Diego Torres
+ * @date 2025
+ * @copyright Copyright (C) 2025 Diego Torres. All rights reserved.
+ */
+/**************************************************************************************************/
+
+#include "gui/gui_qt_settings.h"
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QSettings>
+
+using namespace Orogena::GUI;
+using namespace Orogena::Core;
+
+/**************************************************************************************************/
+/**
+ * @brief Test fixture for QtSettings tests
+ *
+ * @details
+ * Provides setup and teardown for settings testing. Uses a custom organization/application
+ * name to avoid interfering with actual application settings.
+ */
+class QtSettingsTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        // Use unique organization/app name for testing
+        m_Settings = std::make_unique<QtSettings>("OrogenaTest", "SettingsTest");
+
+        // Clear any existing test settings
+        m_Settings->Clear();
+        m_Settings->Sync();
+    }
+
+    void TearDown() override
+    {
+        // Clean up test settings
+        if (m_Settings)
+        {
+            m_Settings->Clear();
+            m_Settings->Sync();
+        }
+    }
+
+    std::unique_ptr<QtSettings> m_Settings;
+};
+
+/**************************************************************************************************/
+// String Settings Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, SetAndGetString)
+{
+    // Arrange
+    const std::string key = "test/string";
+    const std::string value = "Hello, World!";
+
+    // Act
+    m_Settings->SetString(key, value);
+    auto retrieved = m_Settings->GetString(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, GetNonexistentStringReturnsNullopt)
+{
+    // Arrange & Act
+    auto retrieved = m_Settings->GetString("nonexistent/key");
+
+    // Assert
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+TEST_F(QtSettingsTest, SetEmptyString)
+{
+    // Arrange
+    const std::string key = "test/empty";
+    const std::string value = "";
+
+    // Act
+    m_Settings->SetString(key, value);
+    auto retrieved = m_Settings->GetString(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+/**************************************************************************************************/
+// Integer Settings Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, SetAndGetInt)
+{
+    // Arrange
+    const std::string key = "test/int";
+    const int32_t value = 42;
+
+    // Act
+    m_Settings->SetInt(key, value);
+    auto retrieved = m_Settings->GetInt(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, GetNonexistentIntReturnsNullopt)
+{
+    // Arrange & Act
+    auto retrieved = m_Settings->GetInt("nonexistent/int");
+
+    // Assert
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+TEST_F(QtSettingsTest, SetNegativeInt)
+{
+    // Arrange
+    const std::string key = "test/negative";
+    const int32_t value = -12345;
+
+    // Act
+    m_Settings->SetInt(key, value);
+    auto retrieved = m_Settings->GetInt(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+/**************************************************************************************************/
+// 64-bit Integer Settings Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, SetAndGetInt64)
+{
+    // Arrange
+    const std::string key = "test/int64";
+    const int64_t value = 9223372036854775807LL; // Max int64_t
+
+    // Act
+    m_Settings->SetInt64(key, value);
+    auto retrieved = m_Settings->GetInt64(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, GetNonexistentInt64ReturnsNullopt)
+{
+    // Arrange & Act
+    auto retrieved = m_Settings->GetInt64("nonexistent/int64");
+
+    // Assert
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+/**************************************************************************************************/
+// Floating-point Settings Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, SetAndGetFloat)
+{
+    // Arrange
+    const std::string key = "test/float";
+    const float64_t value = 3.14159265358979;
+
+    // Act
+    m_Settings->SetFloat(key, value);
+    auto retrieved = m_Settings->GetFloat(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_DOUBLE_EQ(value, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, GetNonexistentFloatReturnsNullopt)
+{
+    // Arrange & Act
+    auto retrieved = m_Settings->GetFloat("nonexistent/float");
+
+    // Assert
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+TEST_F(QtSettingsTest, SetNegativeFloat)
+{
+    // Arrange
+    const std::string key = "test/negative_float";
+    const float64_t value = -2.71828;
+
+    // Act
+    m_Settings->SetFloat(key, value);
+    auto retrieved = m_Settings->GetFloat(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_DOUBLE_EQ(value, retrieved.value());
+}
+
+/**************************************************************************************************/
+// Boolean Settings Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, SetAndGetBoolTrue)
+{
+    // Arrange
+    const std::string key = "test/bool_true";
+
+    // Act
+    m_Settings->SetBool(key, true);
+    auto retrieved = m_Settings->GetBool(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_TRUE(retrieved.value());
+}
+
+TEST_F(QtSettingsTest, SetAndGetBoolFalse)
+{
+    // Arrange
+    const std::string key = "test/bool_false";
+
+    // Act
+    m_Settings->SetBool(key, false);
+    auto retrieved = m_Settings->GetBool(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_FALSE(retrieved.value());
+}
+
+TEST_F(QtSettingsTest, GetNonexistentBoolReturnsNullopt)
+{
+    // Arrange & Act
+    auto retrieved = m_Settings->GetBool("nonexistent/bool");
+
+    // Assert
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+/**************************************************************************************************/
+// String List Settings Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, SetAndGetStringList)
+{
+    // Arrange
+    const std::string key = "test/stringlist";
+    const std::vector<std::string> value = {
+        "/path/to/project1.oro",
+        "/path/to/project2.oro",
+        "/path/to/project3.oro"
+    };
+
+    // Act
+    m_Settings->SetStringList(key, value);
+    auto retrieved = m_Settings->GetStringList(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, SetEmptyStringList)
+{
+    // Arrange
+    const std::string key = "test/empty_list";
+    const std::vector<std::string> value = {};
+
+    // Act
+    m_Settings->SetStringList(key, value);
+    auto retrieved = m_Settings->GetStringList(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_TRUE(retrieved.value().empty());
+}
+
+TEST_F(QtSettingsTest, GetNonexistentStringListReturnsNullopt)
+{
+    // Arrange & Act
+    auto retrieved = m_Settings->GetStringList("nonexistent/list");
+
+    // Assert
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+/**************************************************************************************************/
+// Utility Methods Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, ContainsReturnsTrueForExistingKey)
+{
+    // Arrange
+    const std::string key = "test/exists";
+    m_Settings->SetString(key, "value");
+
+    // Act & Assert
+    EXPECT_TRUE(m_Settings->Contains(key));
+}
+
+TEST_F(QtSettingsTest, ContainsReturnsFalseForNonexistentKey)
+{
+    // Arrange & Act & Assert
+    EXPECT_FALSE(m_Settings->Contains("nonexistent/key"));
+}
+
+TEST_F(QtSettingsTest, RemoveDeletesKey)
+{
+    // Arrange
+    const std::string key = "test/to_remove";
+    m_Settings->SetString(key, "value");
+    ASSERT_TRUE(m_Settings->Contains(key));
+
+    // Act
+    m_Settings->Remove(key);
+
+    // Assert
+    EXPECT_FALSE(m_Settings->Contains(key));
+}
+
+TEST_F(QtSettingsTest, ClearRemovesAllSettings)
+{
+    // Arrange
+    m_Settings->SetString("key1", "value1");
+    m_Settings->SetInt("key2", 42);
+    m_Settings->SetBool("key3", true);
+
+    // Act
+    m_Settings->Clear();
+
+    // Assert
+    EXPECT_FALSE(m_Settings->Contains("key1"));
+    EXPECT_FALSE(m_Settings->Contains("key2"));
+    EXPECT_FALSE(m_Settings->Contains("key3"));
+}
+
+TEST_F(QtSettingsTest, SyncPersistsSettings)
+{
+    // Arrange
+    const std::string key = "test/persist";
+    const std::string value = "persistent_value";
+    m_Settings->SetString(key, value);
+
+    // Act
+    m_Settings->Sync();
+
+    // Create new settings instance to verify persistence
+    auto newSettings = std::make_unique<QtSettings>("OrogenaTest", "SettingsTest");
+    auto retrieved = newSettings->GetString(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+/**************************************************************************************************/
+// Group Management Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, BeginGroupCreatesHierarchy)
+{
+    // Arrange
+    m_Settings->BeginGroup("window");
+    m_Settings->SetInt("width", 1024);
+    m_Settings->SetInt("height", 768);
+    m_Settings->EndGroup();
+
+    // Act
+    auto width = m_Settings->GetInt("window/width");
+    auto height = m_Settings->GetInt("window/height");
+
+    // Assert
+    ASSERT_TRUE(width.has_value());
+    ASSERT_TRUE(height.has_value());
+    EXPECT_EQ(1024, width.value());
+    EXPECT_EQ(768, height.value());
+}
+
+TEST_F(QtSettingsTest, NestedGroupsWork)
+{
+    // Arrange
+    m_Settings->BeginGroup("rendering");
+    m_Settings->BeginGroup("quality");
+    m_Settings->SetString("shadows", "high");
+    m_Settings->EndGroup();
+    m_Settings->EndGroup();
+
+    // Act
+    auto shadows = m_Settings->GetString("rendering/quality/shadows");
+
+    // Assert
+    ASSERT_TRUE(shadows.has_value());
+    EXPECT_EQ("high", shadows.value());
+}
+
+TEST_F(QtSettingsTest, EndGroupRestoresPreviousContext)
+{
+    // Arrange
+    m_Settings->BeginGroup("group1");
+    m_Settings->SetInt("value", 1);
+    m_Settings->EndGroup();
+
+    m_Settings->BeginGroup("group2");
+    m_Settings->SetInt("value", 2);
+    m_Settings->EndGroup();
+
+    // Act
+    auto value1 = m_Settings->GetInt("group1/value");
+    auto value2 = m_Settings->GetInt("group2/value");
+
+    // Assert
+    ASSERT_TRUE(value1.has_value());
+    ASSERT_TRUE(value2.has_value());
+    EXPECT_EQ(1, value1.value());
+    EXPECT_EQ(2, value2.value());
+}
+
+/**************************************************************************************************/
+// Overwrite Tests
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, OverwriteExistingValue)
+{
+    // Arrange
+    const std::string key = "test/overwrite";
+    m_Settings->SetInt(key, 42);
+
+    // Act
+    m_Settings->SetInt(key, 100);
+    auto retrieved = m_Settings->GetInt(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(100, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, ChangeValueType)
+{
+    // Arrange
+    const std::string key = "test/type_change";
+    m_Settings->SetInt(key, 42);
+
+    // Act - Change from int to string
+    m_Settings->SetString(key, "now a string");
+    auto retrieved = m_Settings->GetString(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ("now a string", retrieved.value());
+}
+
+/**************************************************************************************************/
+// Edge Cases
+/**************************************************************************************************/
+
+TEST_F(QtSettingsTest, KeyWithSpecialCharacters)
+{
+    // Arrange
+    const std::string key = "test/special/!@#$%/key";
+    const std::string value = "special_value";
+
+    // Act
+    m_Settings->SetString(key, value);
+    auto retrieved = m_Settings->GetString(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}
+
+TEST_F(QtSettingsTest, ValueWithUnicodeCharacters)
+{
+    // Arrange
+    const std::string key = "test/unicode";
+    const std::string value = "Hello 世界 🌍";
+
+    // Act
+    m_Settings->SetString(key, value);
+    auto retrieved = m_Settings->GetString(key);
+
+    // Assert
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(value, retrieved.value());
+}


### PR DESCRIPTION
This pull request introduces a framework-independent settings interface to the core logic and provides a Qt-based implementation for use in the GUI. It also integrates the new settings system into the build and test infrastructure. The main changes are grouped below by theme.

**Settings System Abstraction and Implementation**

* Added a new abstract interface `ISettings` in `core/core_settings_interface.h` for managing application settings using standard C++ types, decoupling core logic from Qt dependencies.
* Implemented a concrete Qt-based class `QtSettings` in `gui/gui_qt_settings.h` and `gui/gui_qt_settings.cpp`, which uses `QSettings` to persist settings and bridges between Qt and standard C++ types. [[1]](diffhunk://#diff-7ce3e3dc973f5c749673ab63fd42cccf402a36546d0c3c2fb1faefe400f1c071R1-R97) [[2]](diffhunk://#diff-6c02a43bfa2ac5c738df63cc6c2dff52aa3a92ec52b75ca7bbb29d1326365ccbR1-R219)

**Build System Integration**

* Updated `src/CMakeLists.txt` to include the new settings implementation files (`gui/gui_qt_settings.cpp`, `gui/gui_qt_settings.h`) in the `orogena_gui` library build.

**Testing Infrastructure**

* Added a new unit test source file `unit/gui/test_qt_settings.cpp` to the test suite in `tests/CMakeLists.txt`.
* Linked the test executable against the new `orogena_gui` library and Qt Core to support settings tests.