### PR TITLE
ORO-103 Refactor variable declarations for consistency in test files

### DIFF
--- a/tests/unit/database/test_database_manager.cpp
+++ b/tests/unit/database/test_database_manager.cpp
@@ -35,8 +35,8 @@ class DatabaseTestEnvironment : public ::testing::Environment
         if (!QCoreApplication::instance())
         {
             // Create fake argc/argv for QCoreApplication
-            static int argc = 1;
-            static char appName[] = "test_database_manager";
+            static int   argc = 1;
+            static char  appName[] = "test_database_manager";
             static char* argv[] = {appName, nullptr};
             m_App = std::make_unique<QCoreApplication>(argc, argv);
         }
@@ -93,7 +93,7 @@ class DatabaseManagerTest : public ::testing::Test
     }
 
     std::filesystem::path m_TestDbPath;
-    DatabaseManager* m_Database{nullptr};
+    DatabaseManager*      m_Database{nullptr};
 };
 
 //=================================================================================================
@@ -513,8 +513,8 @@ TEST_F(DatabaseManagerTest, DISABLED_ConcurrentQueriesUsePool)
                                              auto error = m_Database->GetLastError();
                                              if (error)
                                              {
-                                                 std::cerr << "Query failed for i=" << i
-                                                           << ": " << error->message << std::endl;
+                                                 std::cerr << "Query failed for i=" << i << ": "
+                                                           << error->message << std::endl;
                                              }
                                          }
                                          return result.has_value() && !result->IsEmpty();
@@ -522,7 +522,7 @@ TEST_F(DatabaseManagerTest, DISABLED_ConcurrentQueriesUsePool)
     }
 
     // Wait for all queries to complete
-    bool allSucceeded = true;
+    bool    allSucceeded = true;
     int32_t failureCount = 0;
     for (auto& future : futures)
     {
@@ -548,7 +548,7 @@ TEST_F(DatabaseManagerTest, PoolBlocksWhenAllConnectionsBusy)
     m_Database->Connect(m_TestDbPath.string());
 
     // Act - start 3 concurrent operations (should block on 3rd)
-    std::atomic<int32_t> completedCount{0};
+    std::atomic<int32_t>     completedCount{0};
     std::vector<std::thread> threads;
 
     for (int32_t i = 0; i < 3; ++i)

--- a/tests/unit/utils/test_logger.cpp
+++ b/tests/unit/utils/test_logger.cpp
@@ -100,7 +100,7 @@ class LoggerTest : public ::testing::Test
      */
     static std::filesystem::path FindLatestLogFile()
     {
-        std::filesystem::path latest_file;
+        std::filesystem::path           latest_file;
         std::filesystem::file_time_type latest_time{};
 
         for (const auto& entry : std::filesystem::directory_iterator("."))
@@ -226,7 +226,7 @@ TEST_F(LoggerTest, TraceMessageWrittenToFile)
 
     // Assert - Check file contains trace message
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test trace message") != std::string::npos)
         << "Trace message not found in log file";
 }
@@ -239,7 +239,7 @@ TEST_F(LoggerTest, DebugMessageWrittenToFile)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test debug message") != std::string::npos)
         << "Debug message not found in log file";
 }
@@ -252,7 +252,7 @@ TEST_F(LoggerTest, InfoMessageWrittenToFile)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test info message") != std::string::npos)
         << "Info message not found in log file";
 }
@@ -265,7 +265,7 @@ TEST_F(LoggerTest, WarnMessageWrittenToFile)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test warning message") != std::string::npos)
         << "Warning message not found in log file";
 }
@@ -278,7 +278,7 @@ TEST_F(LoggerTest, ErrorMessageWrittenToFile)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test error message") != std::string::npos)
         << "Error message not found in log file";
 }
@@ -291,7 +291,7 @@ TEST_F(LoggerTest, CriticalMessageWrittenToFile)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test critical message") != std::string::npos)
         << "Critical message not found in log file";
 }
@@ -311,7 +311,7 @@ TEST_F(LoggerTest, FormattedMessageWithSingleArgument)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Test value: 42") != std::string::npos)
         << "Formatted message not found in log file";
 }
@@ -319,8 +319,8 @@ TEST_F(LoggerTest, FormattedMessageWithSingleArgument)
 TEST_F(LoggerTest, FormattedMessageWithMultipleArguments)
 {
     // Arrange
-    int x = 10;
-    int y = 20;
+    int         x = 10;
+    int         y = 20;
     std::string operation = "add";
 
     // Act
@@ -329,7 +329,7 @@ TEST_F(LoggerTest, FormattedMessageWithMultipleArguments)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Operation: add with values x=10, y=20") != std::string::npos)
         << "Formatted message not found in log file";
 }
@@ -345,7 +345,7 @@ TEST_F(LoggerTest, FormattedMessageWithFloatingPoint)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Pi value: 3.14") != std::string::npos)
         << "Formatted floating point message not found in log file";
 }
@@ -368,7 +368,7 @@ TEST_F(LoggerTest, SetLevelFiltersLowerPriorityMessages)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
 
     EXPECT_TRUE(log_contents.find("This debug message should not appear") == std::string::npos)
         << "Debug message should be filtered out";
@@ -396,7 +396,7 @@ TEST_F(LoggerTest, SetConsoleLevelIndependentFromFileLevel)
     // Assert
     // All messages should be in file (TRACE level)
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
 
     EXPECT_TRUE(log_contents.find("Trace message") != std::string::npos)
         << "Trace message should be in file";
@@ -420,7 +420,7 @@ TEST_F(LoggerTest, ConvenienceAliasWorks)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find("Testing convenience alias") != std::string::npos)
         << "Message logged via convenience alias not found";
 }
@@ -450,7 +450,7 @@ TEST_F(LoggerTest, VeryLongMessageLogged)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
     EXPECT_TRUE(log_contents.find(long_message) != std::string::npos)
         << "Long message not found in log file";
 }
@@ -476,8 +476,8 @@ TEST_F(LoggerTest, SpecialCharactersInMessage)
 TEST_F(LoggerTest, ConcurrentLoggingDoesNotCrash)
 {
     // Arrange
-    constexpr int c_NumThreads = 10;
-    constexpr int c_MessagesPerThread = 100;
+    constexpr int            c_NumThreads = 10;
+    constexpr int            c_MessagesPerThread = 100;
     std::vector<std::thread> threads;
     threads.reserve(c_NumThreads);
 
@@ -502,7 +502,7 @@ TEST_F(LoggerTest, ConcurrentLoggingDoesNotCrash)
 
     // Assert
     std::filesystem::path log_file = FindLatestLogFile();
-    std::string log_contents = ReadFile(log_file);
+    std::string           log_contents = ReadFile(log_file);
 
     // Verify at least some messages from each thread are present
     for (int t = 0; t < c_NumThreads; ++t)


### PR DESCRIPTION
This pull request makes a minor formatting adjustment to an error logging statement in the `DISABLED_ConcurrentQueriesUsePool` test. The change improves the readability of the output by reformatting how the error message is concatenated in the `std::cerr` stream.

- Reformatted the error logging statement in `TEST_F(DatabaseManagerTest, DISABLED_ConcurrentQueriesUsePool)` to improve output readability in `test_database_manager.cpp`.